### PR TITLE
autoload http extension

### DIFF
--- a/src/zip_file_system.cpp
+++ b/src/zip_file_system.cpp
@@ -252,12 +252,7 @@ vector<string> ZipFileSystem::Glob(const string &path, FileOpener *opener) {
 
   // Get matching zip files
   auto &fs = FileSystem::GetFileSystem(*context);
-  vector<string> matching_zips;
-  if (HasGlob(zip_path)) {
-    matching_zips = fs.Glob(zip_path);
-  } else {
-    matching_zips.push_back(zip_path);
-  }
+  vector<string> matching_zips = fs.GlobFiles(zip_path, *context);
 
   Value zipfs_extension_value = ".zip";
   Value zipfs_extension_remove_value = false;


### PR DESCRIPTION
No test available for this
```
% ./build/release/duckdb
v1.2.2 7c039464e4
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D load zipfs;
D set zipfs_extension = '!!';
D set zipfs_extension_remove = true;
D select *
  FROM 'zip://https://api.insee.fr/melodi/file/DS_TOUR_CAP/DS_TOUR_CAP_CSV_FR!!DS_TOUR_CAP_data.csv' limit 1;

Missing Extension Error:
File https://api.insee.fr/melodi/file/DS_TOUR_CAP/DS_TOUR_CAP_CSV_FR requires the extension httpfs to be loaded

Please try installing and loading the httpfs extension by running:
INSTALL httpfs;
LOAD httpfs;

Alternatively, consider enabling auto-install and auto-load by running:
SET autoinstall_known_extensions=1;
SET autoload_known_extensions=1;
D
D SET autoload_known_extensions=1;
D select *
  FROM 'zip://https://api.insee.fr/melodi/file/DS_TOUR_CAP/DS_TOUR_CAP_CSV_FR!!DS_TOUR_CAP_data.csv' limit 1;

┌──────────┬─────────┬─────────┬────────────┬───┬──────────────┬──────────────────┬─────────────┬───────────┐
│ ACTIVITY │  FREQ   │   GEO   │ GEO_OBJECT │ … │ TOUR_MEASURE │ UNIT_LOC_RANKING │ TIME_PERIOD │ OBS_VALUE │
│ varchar  │ varchar │ varchar │  varchar   │   │   varchar    │     varchar      │    int64    │   int64   │
├──────────┼─────────┼─────────┼────────────┼───┼──────────────┼──────────────────┼─────────────┼───────────┤
│ I552B    │ A       │ 67494   │ COM        │ … │ UNIT_LOC     │ _T               │    2025     │     0     │
├──────────┴─────────┴─────────┴────────────┴───┴──────────────┴──────────────────┴─────────────┴───────────┤
│ 1 rows                                                                                9 columns (8 shown) │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────┘
D
```