### PR TITLE
File exists

### DIFF
--- a/src/include/zip_file_system.hpp
+++ b/src/include/zip_file_system.hpp
@@ -44,6 +44,8 @@ public:
   idx_t SeekPosition(FileHandle &handle) override;
   std::string GetName() const override { return "ZipFileSystem"; }
   vector<OpenFileInfo> Glob(const string &path, FileOpener *opener) override;
+  bool FileExists(const string &filename,
+                  optional_ptr<FileOpener> opener) override;
 
   bool CanHandleFile(const string &fpath) override;
   bool OnDiskFile(FileHandle &handle) override;

--- a/src/zip_file_system.cpp
+++ b/src/zip_file_system.cpp
@@ -405,4 +405,18 @@ vector<OpenFileInfo> ZipFileSystem::Glob(const string &path,
   return result;
 }
 
+bool ZipFileSystem::FileExists(const string &filename,
+                               optional_ptr<FileOpener> opener) {
+  // Remove the "zip://" prefix
+  auto context = opener->TryGetClientContext();
+  const auto parts = SplitArchivePath(filename.substr(6), *context);
+  auto &zip_path = parts.first;
+  auto &file_path = parts.second;
+
+  // Get matching zip files
+  auto &fs = FileSystem::GetFileSystem(*context);
+  // Do not pass opener here, as it will crash later.
+  return fs.FileExists(zip_path);
+}
+
 } // namespace duckdb

--- a/test/sql/zipfs_read_csv.test
+++ b/test/sql/zipfs_read_csv.test
@@ -11,6 +11,11 @@ SELECT * FROM 'zip://examples/a.zip/a.csv'
 4	5	6
 7	8	9
 
+statement error
+SELECT * FROM 'zip://examples-not-found/a.zip'
+----
+Catalog Error: Table with name zip://examples-not-found/a.zip does not exist!
+
 query I
 SELECT * FROM 'zip://examples/a.zip/b.csv'
 ----

--- a/test/sql/zipfs_write.test
+++ b/test/sql/zipfs_write.test
@@ -10,4 +10,4 @@ COPY
     TO 'zip://example/output.zip/test.csv'
     (FORMAT 'csv');
 ----
-Not implemented Error: ZipFileSystem: FileExists is not implemented!
+IO Error: Zip file system can only open for reading


### PR DESCRIPTION
Fixes #28
I am not really clear if this is a correct implementation because `return fs.FileExists(zip_path);` seems to not be able to accept any context being passed into it, which seems wrong.

Here is the failure if opener is passed in:
```
./build/release/"/test/unittest" "/Users/isaac/oss/duckdb-zipfs/test/*"
Filters: /Users/isaac/oss/duckdb-zipfs/test/*
[3/4] (75%): /Users/isaac/oss/duckdb-zipfs/test/sql/zipfs_write.test            ================================================================================
Query failed with internal exception! (/Users/isaac/oss/duckdb-zipfs/test/sql/zipfs_write.test:7)!
================================================================================
COPY
    (FROM generate_series(100_000))
    TO 'zip://example/output.zip/test.csv'
    (FORMAT 'csv');
Actual result:
================================================================================
INTERNAL Error: OpenerFileSystem cannot take an opener - the opener is pushed automatically

Stack Trace:

0        duckdb::Exception::Exception(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 64
1        duckdb::OpenerFileSystem::VerifyNoOpener(duckdb::optional_ptr<duckdb::FileOpener, true>) + 92
2        duckdb::OpenerFileSystem::FileExists(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, duckdb::optional_ptr<duckdb::FileOpener, true>) + 32
3        duckdb::ZipFileSystem::FileExists(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, duckdb::optional_ptr<duckdb::FileOpener, true>) + 152
4        duckdb::Binder::BindCopyTo(duckdb::CopyStatement&, duckdb::CopyToType) + 3888
5        duckdb::Binder::Bind(duckdb::CopyStatement&, duckdb::CopyToType) + 820
6        duckdb::Planner::CreatePlan(duckdb::SQLStatement&) + 152
7        duckdb::ClientContext::CreatePreparedStatementInternal(duckdb::ClientContextLock&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>, duckdb::optional_ptr<std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, duckdb::BoundParameterData, duckdb::CaseInsensitiveStringHashFunction, duckdb::CaseInsensitiveStringEquality, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, duckdb::BoundParameterData>>>, true>) + 484
8        duckdb::ClientContext::CreatePreparedStatement(duckdb::ClientContextLock&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>, duckdb::optional_ptr<std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, duckdb::BoundParameterData, duckdb::CaseInsensitiveStringHashFunction, duckdb::CaseInsensitiveStringEquality, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, duckdb::BoundParameterData>>>, true>, duckdb::PreparedStatementMode) + 916
9        duckdb::ClientContext::PendingStatementInternal(duckdb::ClientContextLock&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>, duckdb::PendingQueryParameters const&) + 128
10       duckdb::ClientContext::PendingStatementOrPreparedStatement(duckdb::ClientContextLock&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>, duckdb::shared_ptr<duckdb::PreparedStatementData, true>&, duckdb::PendingQueryParameters const&) + 208
11       duckdb::ClientContext::PendingStatementOrPreparedStatementInternal(duckdb::ClientContextLock&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>, duckdb::shared_ptr<duckdb::PreparedStatementData, true>&, duckdb::PendingQueryParameters const&) + 1556
12       duckdb::ClientContext::PendingQueryInternal(duckdb::ClientContextLock&, duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>, duckdb::PendingQueryParameters const&, bool) + 120
13       duckdb::ClientContext::Query(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool) + 292
14       duckdb::Connection::Query(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 44
15       duckdb::Command::ExecuteQuery(duckdb::ExecuteContext&, duckdb::Connection*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, unsigned long long) const + 116
16       duckdb::Statement::ExecuteInternal(duckdb::ExecuteContext&) const + 264
17       duckdb::SQLLogicTestRunner::ExecuteCommand(duckdb::unique_ptr<duckdb::Command, std::__1::default_delete<duckdb::Command>, true>) + 140
18       duckdb::SQLLogicTestRunner::ExecuteFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>) + 7936
19       void testRunner<false, true>() + 1324
20       Catch::RunContext::invokeActiveTestCase() + 216
21       Catch::RunContext::runCurrentTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) + 328
22       Catch::RunContext::runTest(Catch::TestCase const&) + 316
23       Catch::Session::runInternal() + 3868
24       Catch::Session::run() + 156
25       main + 3820
26       start + 2840

This error signals an assertion failure within DuckDB. This usually occurs due to unexpected conditions or errors in the program's logic.
For more information, see https://duckdb.org/docs/stable/dev/internal_errors


~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
unittest is a Catch v2.13.7 host application.
Run with -? for options

-------------------------------------------------------------------------------
/Users/isaac/oss/duckdb-zipfs/test/sql/zipfs_write.test
-------------------------------------------------------------------------------
/Users/isaac/oss/duckdb-zipfs/duckdb/test/sqlite/test_sqllogictest.cpp:224
...............................................................................

/Users/isaac/oss/duckdb-zipfs/test/sql/zipfs_write.test:7: FAILED:
explicitly with message:
  0

[4/4] (100%): /Users/isaac/oss/duckdb-zipfs/test/sql/zipfs_write.test
===============================================================================
test cases:   4 |   3 passed | 1 failed
assertions: 196 | 195 passed | 1 failed

make: *** [test_release_internal] Error 1
```