### PR TITLE
Bump vcpkg deps and add LINKED_LIBS for Wasm compilation

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -4,6 +4,7 @@
 duckdb_extension_load(zipfs
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
     LOAD_TESTS
+    LINKED_LIBS "../../vcpkg_installed/wasm32-emscripten/lib/libminiz.a"
 )
 
 # Any extra extensions that should be built

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,10 +7,10 @@
       {
         "kind": "git",
         "repository": "https://github.com/duckdb/vcpkg-duckdb-ports",
-        "baseline": "0f9bf648ba1ee29291890a1ca9a49a80bba017eb",
+        "baseline": "869bddccca976e0abe25894356e7f49e77765169",
         "packages": [ "vcpkg-cmake" ]
       }
     ]
   },
-  "builtin-baseline" : "5e5d0e1cd7785623065e77eff011afdeec1a3574"
+  "builtin-baseline" : "ce613c41372b23b1f51333815feb3edd87ef8a8b"
 }


### PR DESCRIPTION
Solves https://github.com/isaacbrodsky/duckdb-zipfs/issues/42

3 changes:
* adding LINKED_LIBS pointing to libminiz.a
* changing baseline for vcpkg (to the one used across duckdb)
* changing baseline for vcpkg-duckdb-ports (to latest one)