### PR TITLE
add zipstream:// protocol to allow sequential streaming

### DIFF
--- a/src/include/zip_file_system.hpp
+++ b/src/include/zip_file_system.hpp
@@ -33,6 +33,35 @@ private:
   idx_t seek_offset;
 };
 
+class ZipStreamFileHandle final : public FileHandle {
+  friend class ZipStreamFileSystem;
+
+public:
+  ZipStreamFileHandle(FileSystem &file_system, const string &path,
+                      FileOpenFlags flags,
+                      unique_ptr<FileHandle> inner_handle_p,
+                      const mz_zip_archive_file_stat &file_stat,
+                      mz_uint file_index)
+      : FileHandle(file_system, path, flags),
+        inner_handle(std::move(inner_handle_p)), file_stat(file_stat),
+        file_index(file_index), iter_state(nullptr), seek_offset(0),
+        closed(false) {
+    mz_zip_zero_struct(&zip);
+  }
+
+  ~ZipStreamFileHandle() override;
+  void Close() override;
+
+private:
+  unique_ptr<FileHandle> inner_handle;
+  mz_zip_archive zip;
+  mz_zip_archive_file_stat file_stat;
+  mz_uint file_index;
+  mz_zip_reader_extract_iter_state *iter_state;
+  idx_t seek_offset;
+  bool closed;
+};
+
 class ZipFileSystem final : public FileSystem {
 public:
   explicit ZipFileSystem() : FileSystem() {}
@@ -47,6 +76,34 @@ public:
   void Reset(FileHandle &handle) override;
   idx_t SeekPosition(FileHandle &handle) override;
   std::string GetName() const override { return "ZipFileSystem"; }
+  vector<OpenFileInfo> Glob(const string &path, FileOpener *opener) override;
+  bool FileExists(const string &filename,
+                  optional_ptr<FileOpener> opener) override;
+
+  bool CanHandleFile(const string &fpath) override;
+  bool OnDiskFile(FileHandle &handle) override;
+  bool CanSeek() override;
+
+  unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+                                  optional_ptr<FileOpener> opener) override;
+
+private:
+};
+
+class ZipStreamFileSystem final : public FileSystem {
+public:
+  explicit ZipStreamFileSystem() : FileSystem() {}
+
+  timestamp_t GetLastModifiedTime(FileHandle &handle) override;
+  FileType GetFileType(FileHandle &handle) override;
+  int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
+  void Read(FileHandle &handle, void *buffer, int64_t nr_bytes,
+            idx_t location) override;
+  int64_t GetFileSize(FileHandle &handle) override;
+  void Seek(FileHandle &handle, idx_t location) override;
+  void Reset(FileHandle &handle) override;
+  idx_t SeekPosition(FileHandle &handle) override;
+  std::string GetName() const override { return "ZipStreamFileSystem"; }
   vector<OpenFileInfo> Glob(const string &path, FileOpener *opener) override;
   bool FileExists(const string &filename,
                   optional_ptr<FileOpener> opener) override;

--- a/src/zip_file_system.cpp
+++ b/src/zip_file_system.cpp
@@ -1,8 +1,8 @@
 #include "zip_file_system.hpp"
 
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/file_opener.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
 #include "duckdb/main/client_context.hpp"
 
@@ -424,6 +424,501 @@ bool ZipFileSystem::FileExists(const string &filename,
   // Remove the "zip://" prefix
   auto context = opener->TryGetClientContext();
   const auto parts = SplitArchivePath(filename.substr(6), *context);
+  auto &zip_path = parts.first;
+  auto &file_path = parts.second;
+
+  auto &fs = FileSystem::GetFileSystem(*context);
+  // Do not pass opener here, as it will crash later.
+  if (!fs.FileExists(zip_path)) {
+    return false;
+  }
+
+  auto normalized_file_path = StringUtil::Replace(
+      file_path, fs.PathSeparator(file_path), ZIP_SEPARATOR);
+
+  auto handle = fs.OpenFile(zip_path, FileOpenFlags::FILE_FLAGS_READ);
+  if (!handle) {
+    return false;
+  }
+
+  if (!handle->CanSeek()) {
+    // TODO: Buffer?
+    return false;
+  }
+
+  idx_t size = handle->GetFileSize();
+
+  mz_zip_archive zip;
+  mz_zip_zero_struct(&zip);
+  zip.m_pRead = &FileSystemZipReadFunc;
+  zip.m_pIO_opaque = handle.get();
+  try {
+    mz_uint zip_flags = 0;
+
+    if (!mz_zip_reader_init(&zip, size, zip_flags)) {
+      return false;
+    }
+
+    mz_uint file_index = 0;
+    auto locate_failed =
+        mz_zip_reader_locate_file_v2(&zip, normalized_file_path.c_str(),
+                                     nullptr, 0, &file_index) == MZ_FALSE;
+    if (locate_failed) {
+      return false;
+    }
+
+    mz_zip_archive_file_stat file_stat = {0};
+    auto stat_failed =
+        mz_zip_reader_file_stat(&zip, file_index, &file_stat) == MZ_FALSE;
+
+    if (stat_failed) {
+      return false;
+    }
+    if ((file_stat.m_method) && (file_stat.m_method != MZ_DEFLATED)) {
+      return false;
+    }
+
+    mz_zip_reader_end(&zip);
+
+    return true;
+  } catch (Exception &ex) {
+    mz_zip_reader_end(&zip);
+    throw;
+  }
+}
+
+//------------------------------------------------------------------------------
+// Zip Stream File Handle
+//------------------------------------------------------------------------------
+
+ZipStreamFileHandle::~ZipStreamFileHandle() {
+  try {
+    Close();
+  } catch (...) { // NOLINT
+  }
+}
+
+void ZipStreamFileHandle::Close() {
+  if (closed) {
+    return;
+  }
+  closed = true;
+
+  if (iter_state) {
+    mz_zip_reader_extract_iter_free(iter_state);
+    iter_state = nullptr;
+  }
+
+  if (zip.m_pState) {
+    mz_zip_reader_end(&zip);
+    mz_zip_zero_struct(&zip);
+  }
+
+  if (inner_handle) {
+    inner_handle->Close();
+  }
+}
+
+//------------------------------------------------------------------------------
+// Zip Stream File System
+//------------------------------------------------------------------------------
+
+bool ZipStreamFileSystem::CanHandleFile(const string &fpath) {
+  // This only checks the URL scheme. We still validate seekability of the
+  // underlying zip archive in OpenFile(). Even though zipstream:// exposes the
+  // selected member as a sequential stream, the outer .zip file itself must be
+  // seekable so miniz can read the central directory and member data.
+  return fpath.size() > 12 && fpath.substr(0, 12) == "zipstream://";
+}
+
+unique_ptr<FileHandle>
+ZipStreamFileSystem::OpenFile(const string &path, FileOpenFlags flags,
+                              optional_ptr<FileOpener> opener) {
+  if (!flags.OpenForReading() || flags.OpenForWriting()) {
+    throw IOException("Zip stream file system can only open for reading");
+  }
+
+  // Get the path to the zip file
+  auto context = opener->TryGetClientContext();
+  const auto paths = SplitArchivePath(path.substr(12), *context);
+  const auto &zip_path = paths.first;
+  const auto &file_path = paths.second;
+
+  // Now we need to find the file within the zip file and return our file handle
+  auto &fs = FileSystem::GetFileSystem(*context);
+  auto handle = fs.OpenFile(zip_path, flags);
+  if (!handle) {
+    throw IOException("Failed to open file: %s", zip_path);
+  }
+
+  if (file_path.empty()) {
+    return handle;
+  }
+
+  auto normalized_file_path = StringUtil::Replace(
+      file_path, fs.PathSeparator(file_path), ZIP_SEPARATOR);
+
+  if (!handle->CanSeek()) {
+    // TODO: Buffer?
+    throw IOException("Cannot seek");
+  }
+
+  idx_t size = handle->GetFileSize();
+
+  mz_zip_archive zip;
+  mz_zip_zero_struct(&zip);
+  zip.m_pRead = &FileSystemZipReadFunc;
+  zip.m_pIO_opaque = handle.get();
+  mz_zip_reader_extract_iter_state *iter_state = nullptr;
+  try {
+    mz_uint zip_flags = 0;
+
+    if (!mz_zip_reader_init(&zip, size, zip_flags)) {
+      throw IOException("Could not open as zip file: %s",
+                        mz_zip_get_error_string(mz_zip_get_last_error(&zip)));
+    }
+
+    mz_uint file_index = 0;
+    auto locate_failed =
+        mz_zip_reader_locate_file_v2(&zip, normalized_file_path.c_str(),
+                                     nullptr, 0, &file_index) == MZ_FALSE;
+    if (locate_failed) {
+      throw IOException("Failed to find file: %s", normalized_file_path);
+    }
+
+    mz_zip_archive_file_stat file_stat = {0};
+    auto stat_failed =
+        mz_zip_reader_file_stat(&zip, file_index, &file_stat) == MZ_FALSE;
+
+    if (stat_failed) {
+      throw IOException("Problem stat-ing file within archive: %s",
+                        mz_zip_get_error_string(mz_zip_get_last_error(&zip)));
+    }
+    if ((file_stat.m_method) && (file_stat.m_method != MZ_DEFLATED)) {
+      throw IOException("Unknown compression method");
+    }
+
+    iter_state = mz_zip_reader_extract_iter_new(&zip, file_index, 0);
+    if (!iter_state) {
+      throw IOException(
+          "Problem creating zip stream for file within archive: %s",
+          mz_zip_get_error_string(mz_zip_get_last_error(&zip)));
+    }
+
+    auto zip_stream_handle = make_uniq<ZipStreamFileHandle>(
+        *this, path, flags, std::move(handle), file_stat, file_index);
+    zip_stream_handle->zip = zip;
+    mz_zip_zero_struct(&zip);
+    zip_stream_handle->iter_state = iter_state;
+    // miniz stores the mz_zip_archive pointer that was passed to
+    // mz_zip_reader_extract_iter_new() inside the iterator state. The iterator
+    // was created against the local stack variable above, but from this point
+    // on the archive is owned by the ZipStreamFileHandle. Retarget the iterator
+    // to the archive copy in the handle; otherwise reads dereference a dangling
+    // stack pointer after OpenFile() returns.
+    zip_stream_handle->iter_state->pZip = &zip_stream_handle->zip;
+    iter_state = nullptr;
+
+    return zip_stream_handle;
+  } catch (Exception &ex) {
+    if (iter_state) {
+      mz_zip_reader_extract_iter_free(iter_state);
+    }
+    mz_zip_reader_end(&zip);
+    throw;
+  }
+}
+
+void ZipStreamFileSystem::Read(FileHandle &handle, void *buffer,
+                               int64_t nr_bytes, idx_t location) {
+  auto &t_handle = handle.Cast<ZipStreamFileHandle>();
+  auto original_position = t_handle.seek_offset;
+
+  try {
+    Seek(handle, location);
+    Read(handle, buffer, nr_bytes);
+    Seek(handle, original_position);
+  } catch (Exception &ex) {
+    try {
+      Seek(handle, original_position);
+    } catch (...) { // NOLINT
+    }
+    throw;
+  }
+}
+
+int64_t ZipStreamFileSystem::Read(FileHandle &handle, void *buffer,
+                                  int64_t nr_bytes) {
+  auto &t_handle = handle.Cast<ZipStreamFileHandle>();
+  auto remaining_bytes =
+      t_handle.file_stat.m_uncomp_size - t_handle.seek_offset;
+  auto to_read = MinValue(UnsafeNumericCast<idx_t>(nr_bytes), remaining_bytes);
+  if (to_read == 0) {
+    return 0;
+  }
+
+  auto read_bytes =
+      mz_zip_reader_extract_iter_read(t_handle.iter_state, buffer, to_read);
+  if (read_bytes == 0 && to_read > 0) {
+    auto err = mz_zip_get_last_error(&t_handle.zip);
+    if (err != MZ_ZIP_NO_ERROR) {
+      throw IOException("Problem reading file within archive: %s",
+                        mz_zip_get_error_string(err));
+    }
+  }
+
+  t_handle.seek_offset += UnsafeNumericCast<idx_t>(read_bytes);
+  return UnsafeNumericCast<int64_t>(read_bytes);
+}
+
+int64_t ZipStreamFileSystem::GetFileSize(FileHandle &handle) {
+  auto &t_handle = handle.Cast<ZipStreamFileHandle>();
+  return UnsafeNumericCast<int64_t>(t_handle.file_stat.m_uncomp_size);
+}
+
+void ZipStreamFileSystem::Seek(FileHandle &handle, idx_t location) {
+  auto &t_handle = handle.Cast<ZipStreamFileHandle>();
+  auto file_size = UnsafeNumericCast<idx_t>(t_handle.file_stat.m_uncomp_size);
+  auto target_location = MinValue(location, file_size);
+
+  if (target_location < t_handle.seek_offset) {
+    Reset(handle);
+  }
+
+  if (target_location == t_handle.seek_offset) {
+    return;
+  }
+
+  data_t skip_buffer[8192];
+  while (t_handle.seek_offset < target_location) {
+    auto to_skip =
+        MinValue<idx_t>(target_location - t_handle.seek_offset,
+                        UnsafeNumericCast<idx_t>(sizeof(skip_buffer)));
+    auto skipped =
+        Read(handle, skip_buffer, UnsafeNumericCast<int64_t>(to_skip));
+    if (skipped <= 0) {
+      throw IOException("Failed to seek within zip stream");
+    }
+  }
+}
+
+void ZipStreamFileSystem::Reset(FileHandle &handle) {
+  auto &t_handle = handle.Cast<ZipStreamFileHandle>();
+  if (t_handle.iter_state) {
+    mz_zip_reader_extract_iter_free(t_handle.iter_state);
+    t_handle.iter_state = nullptr;
+  }
+
+  auto *iter_state =
+      mz_zip_reader_extract_iter_new(&t_handle.zip, t_handle.file_index, 0);
+  if (!iter_state) {
+    throw IOException(
+        "Problem creating zip stream for file within archive: %s",
+        mz_zip_get_error_string(mz_zip_get_last_error(&t_handle.zip)));
+  }
+
+  t_handle.iter_state = iter_state;
+  t_handle.seek_offset = 0;
+}
+
+idx_t ZipStreamFileSystem::SeekPosition(FileHandle &handle) {
+  auto &t_handle = handle.Cast<ZipStreamFileHandle>();
+  return t_handle.seek_offset;
+}
+
+bool ZipStreamFileSystem::CanSeek() {
+  // We intentionally do not advertise seek support. Some internal operations
+  // can still replay from the start of the member via Seek()/Reset(), but
+  // callers should treat zipstream:// as a sequential stream.
+  return false;
+}
+
+timestamp_t ZipStreamFileSystem::GetLastModifiedTime(FileHandle &handle) {
+  auto &t_handle = handle.Cast<ZipStreamFileHandle>();
+  auto &inner_handle = *t_handle.inner_handle;
+  return inner_handle.file_system.GetLastModifiedTime(inner_handle);
+}
+
+FileType ZipStreamFileSystem::GetFileType(FileHandle &handle) {
+  auto &t_handle = handle.Cast<ZipStreamFileHandle>();
+  auto &inner_handle = *t_handle.inner_handle;
+  return inner_handle.file_system.GetFileType(inner_handle);
+}
+
+bool ZipStreamFileSystem::OnDiskFile(FileHandle &handle) {
+  auto &t_handle = handle.Cast<ZipStreamFileHandle>();
+  return t_handle.inner_handle->OnDiskFile();
+}
+
+vector<OpenFileInfo> ZipStreamFileSystem::Glob(const string &path,
+                                               FileOpener *opener) {
+  // Remove the "zipstream://" prefix
+  auto context = opener->TryGetClientContext();
+  auto &fs = FileSystem::GetFileSystem(*context);
+  const auto parts = SplitArchivePath(path.substr(12), *context);
+  auto &zip_path = parts.first;
+  const auto has_glob = HasGlob(zip_path);
+  auto &file_path = parts.second;
+
+  // Get matching zip files
+  vector<OpenFileInfo> matching_zips;
+  if (has_glob) {
+    matching_zips = fs.GlobFiles(zip_path, FileGlobOptions::DISALLOW_EMPTY);
+  } else {
+    // Normally, GlobFiles would be safe. However, when
+    // there is no glob, we don't call it because it can mangle https:// URLs
+    // (converting slashes into backslashes.)
+    matching_zips = {OpenFileInfo(zip_path)};
+  }
+
+  Value zipfs_split_value = Value(LogicalType::VARCHAR);
+  context->TryGetCurrentSetting("zipfs_split", zipfs_split_value);
+
+  auto extension =
+      !zipfs_split_value.IsNull() ? zipfs_split_value.GetValue<string>() : "";
+
+  vector<OpenFileInfo> result;
+  for (const auto &curr_zip : matching_zips) {
+    if (!HasGlob(file_path)) {
+      // No glob pattern in the file path, just return the file path
+      result.push_back("zipstream://" + curr_zip.path + extension +
+                       ZIP_SEPARATOR + file_path);
+      continue;
+    }
+
+    auto pattern_parts = StringUtil::Split(file_path, ZIP_SEPARATOR);
+    // TODO: We may want to detect globbing into a nested zip file and reject.
+
+    // Given the path to the zip file, open it
+    auto archive_handle = fs.OpenFile(curr_zip, FileFlags::FILE_FLAGS_READ);
+    if (!archive_handle) {
+      continue; // Skip invalid zip files
+    }
+    if (!archive_handle->CanSeek()) {
+      continue; // Skip unseekable files
+    }
+
+    idx_t size = archive_handle->GetFileSize();
+
+    mz_zip_archive zip;
+    mz_zip_zero_struct(&zip);
+    zip.m_pRead = &FileSystemZipReadFunc;
+    zip.m_pIO_opaque = archive_handle.get();
+
+    string zip_filename;
+    const size_t MAX_FILENAME_LEN = 65536; // = 2**16
+    zip_filename.reserve(1024);
+    try {
+      mz_uint flags = 0;
+
+      if (!mz_zip_reader_init(&zip, size, flags)) {
+        throw IOException("Could not open as zip file: %s",
+                          mz_zip_get_error_string(mz_zip_get_last_error(&zip)));
+      }
+
+      mz_uint i, files;
+
+      files = mz_zip_reader_get_num_files(&zip);
+
+      for (i = 0; i < files; i++) {
+        mz_zip_clear_last_error(&zip);
+
+        if (mz_zip_reader_is_file_a_directory(&zip, i))
+          continue;
+
+        mz_zip_validate_file(&zip, i, MZ_ZIP_FLAG_VALIDATE_HEADERS_ONLY);
+
+        if (mz_zip_reader_is_file_encrypted(&zip, i))
+          continue;
+
+        mz_zip_clear_last_error(&zip);
+
+        mz_uint filename_size = mz_zip_reader_get_filename(&zip, i, nullptr, 0);
+        // NOTE: filename_size already contains +1 for the leading \0
+        // Double filename capacity/length until it's enough or larger than
+        // 2**16, where 2**16 should be the max filename length in zip files.
+        if (filename_size > zip_filename.capacity()) {
+          size_t new_capacity =
+              zip_filename.capacity() > 0 ? zip_filename.capacity() : 1;
+          while (new_capacity < filename_size) {
+            new_capacity *= 2;
+            if (new_capacity > MAX_FILENAME_LEN) {
+              throw IOException("Filename too long");
+            }
+          }
+          zip_filename.reserve(new_capacity);
+        }
+        zip_filename.resize(filename_size - 1);
+        mz_zip_reader_get_filename(&zip, i, &zip_filename[0], filename_size);
+
+        if (auto err = mz_zip_get_last_error(&zip)) {
+          throw IOException("Problem getting filename: %s",
+                            mz_zip_get_error_string(err));
+        }
+
+        auto entry_parts = StringUtil::Split(zip_filename, ZIP_SEPARATOR);
+
+        if (entry_parts.size() < pattern_parts.size()) {
+          // This entry is not deep enough to match the pattern
+          continue;
+        }
+
+        // Check if the pattern matches the entry
+        bool match = true;
+        for (idx_t i = 0; i < pattern_parts.size(); i++) {
+          const auto &pp = pattern_parts[i];
+          const auto &ep = entry_parts[i];
+
+          if (pp == "**") {
+            // We only allow crawl's to be at the end of the pattern
+            if (i != pattern_parts.size() - 1) {
+              throw NotImplementedException(
+                  "Recursive globs are only supported at the end of zip file "
+                  "path patterns");
+            }
+            // Otherwise, everything else is a match
+            match = true;
+            break;
+          }
+
+          if (!duckdb::Glob(ep.c_str(), ep.size(), pp.c_str(), pp.size())) {
+            // Not a match
+            match = false;
+            break;
+          }
+
+          if (i == pattern_parts.size() - 1 &&
+              entry_parts.size() > pattern_parts.size()) {
+            // If the entry is deeper than the pattern (and we havent hit a **),
+            // then it is not a match
+            match = false;
+            break;
+          }
+        }
+
+        if (match) {
+          auto entry_path = "zipstream://" + curr_zip.path + extension +
+                            ZIP_SEPARATOR + zip_filename;
+          // Cache here???
+          result.push_back(entry_path);
+        }
+      }
+
+      mz_zip_reader_end(&zip);
+    } catch (Exception &ex) {
+      mz_zip_reader_end(&zip);
+      throw;
+    }
+  }
+
+  return result;
+}
+
+bool ZipStreamFileSystem::FileExists(const string &filename,
+                                     optional_ptr<FileOpener> opener) {
+  // Remove the "zipstream://" prefix
+  auto context = opener->TryGetClientContext();
+  const auto parts = SplitArchivePath(filename.substr(12), *context);
   auto &zip_path = parts.first;
   auto &file_path = parts.second;
 

--- a/src/zipfs_extension.cpp
+++ b/src/zipfs_extension.cpp
@@ -1,15 +1,15 @@
 #include "zipfs_extension.hpp"
-#include "zip_file_system.hpp"
-#include "archive_file_system.hpp"
-#include "noop_archive_file_system.hpp"
-#include "zip_contents.hpp"
 #include "archive_contents.hpp"
-#include "noop_archive_contents.hpp"
+#include "archive_file_system.hpp"
 #include "duckdb.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "noop_archive_contents.hpp"
+#include "noop_archive_file_system.hpp"
+#include "zip_contents.hpp"
+#include "zip_file_system.hpp"
 #include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
 
 namespace duckdb {
@@ -20,6 +20,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 
   auto &fs = loader.GetDatabaseInstance().GetFileSystem();
   fs.RegisterSubSystem(make_uniq<ZipFileSystem>());
+  fs.RegisterSubSystem(make_uniq<ZipStreamFileSystem>());
   loader.RegisterFunction(TableFunction("zip_contents", {LogicalType::VARCHAR},
                                         ReadZipFunction, ReadZipFunctionBind,
                                         ReadZipFunctionInit));

--- a/test/sql/zipstream_read_csv.test
+++ b/test/sql/zipstream_read_csv.test
@@ -1,0 +1,38 @@
+# name: test/sql/zipstream_read_csv.test
+# description: test zipstream support in zipfs extension
+# group: [sql]
+
+require zipfs
+
+query III
+SELECT * FROM read_csv('zipstream://examples/a.zip/a.csv')
+----
+1	2	3
+4	5	6
+7	8	9
+
+query III
+SELECT * FROM read_csv('zipstream://examples/a.zip/*.csv', union_by_name = true)
+----
+1	2	3
+4	5	6
+7	8	9
+99	NULL	NULL
+98	NULL	NULL
+97	NULL	NULL
+
+query IIII
+SELECT * FROM read_csv('zipstream://examples/csv_only.zip', union_by_name = true)
+----
+1	2	3	NULL
+4	5	6	NULL
+7	8	9	NULL
+99	NULL	NULL	NULL
+98	NULL	NULL	NULL
+97	NULL	NULL	NULL
+NULL	NULL	NULL	world
+
+statement error
+SELECT * FROM read_csv('zipstream://examples/a.zip/doesnt_exist.csv')
+----
+Failed to find file

--- a/test/sql/zipstream_read_jsonl.test
+++ b/test/sql/zipstream_read_jsonl.test
@@ -1,0 +1,29 @@
+# name: test/sql/zipstream_read_jsonl.test
+# description: test zipstream json support in zipfs extension
+# group: [sql]
+
+require zipfs
+
+query I
+install json;
+load json;
+select * from read_json('zipstream://examples/a.zip/*.jsonl', union_by_name = true);
+----
+a1
+a2
+b1
+b2
+
+query I
+install json;
+load json;
+select * from read_json('zipstream://examples/*.zip/*.jsonl', union_by_name = true);
+----
+a1
+a2
+b1
+b2
+a1
+a2
+b1
+b2


### PR DESCRIPTION
Closes #49

It would likely technically be possible to implement full streaming support using SOZip (#5) or for other files files we could build an index (https://github.com/forrestfwilliams/zran and similar approaches). I decided to solve the immediate problem instead and add `zipstream://` to allow ingesting CSV/JSON files which do not require full seeking support (`FileHandle::CanSeek()` now returns `false`). This means that parquet files will fail to load with `zipstream://`.

Another approach was considered, `SET zipfs_streaming = true` and use the existing `zip://` protocol but this seems ugly to me. Opened as a draft for feedback, if this approach is not desired I can give a shot to implementing the index-building support for full streaming but it's likely to become extremely complex.