### PR TITLE
feat: stream reads to uncompressed files in zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ This extension is intended more for convience than high performance. It does not
 extension is based) does. As such, operations which require the central directory (index) of the zip file, such as globbing files, must
 reread the central directory multiple times, once for the glob and once for each file to open.
 
-The selected file will be read entirely into memory, not streamed. Therefore it cannot be used to read files which are larger than memory when uncompressed.
+How a member is read depends on how it was stored:
+
+- **Compressed** members (DEFLATE) are decompressed entirely into memory, so they cannot be larger than memory when uncompressed.
+- **Stored** members (uncompressed, `zip -0`) are read directly from their byte range, so a query fetches only what it needs (e.g. a Parquet footer plus the required row groups) — over remote backends (`s3://`, `az://`) as small HTTP range requests rather than a full download.
 
 # Development
 

--- a/src/include/zip_file_system.hpp
+++ b/src/include/zip_file_system.hpp
@@ -12,25 +12,65 @@ auto const ZIP_SEPARATOR = "/";
 size_t FileSystemZipReadFunc(void *pOpaque, mz_uint64 file_ofs, void *pBuf,
                              size_t n);
 
-class ZipFileHandle final : public FileHandle {
+class ZipFileHandle : public FileHandle {
   friend class ZipFileSystem;
 
 public:
   ZipFileHandle(FileSystem &file_system, const string &path,
                 FileOpenFlags flags, unique_ptr<FileHandle> inner_handle_p,
-                const mz_zip_archive_file_stat &file_stat,
-                unique_ptr<data_t[]> data)
+                const mz_zip_archive_file_stat &file_stat)
       : FileHandle(file_system, path, flags),
         inner_handle(std::move(inner_handle_p)), file_stat(file_stat),
-        data(std::move(data)), seek_offset(0) {}
+        seek_offset(0) {}
+
+  virtual void ReadInto(void *buffer, idx_t nr_bytes, idx_t location) = 0;
 
   void Close() override;
 
-private:
+protected:
   unique_ptr<FileHandle> inner_handle;
   mz_zip_archive_file_stat file_stat;
-  unique_ptr<data_t[]> data;
   idx_t seek_offset;
+};
+
+// A compressed (DEFLATE) member decompressed up front into an owned buffer.
+class BufferedZipFileHandle final : public ZipFileHandle {
+public:
+  BufferedZipFileHandle(FileSystem &file_system, const string &path,
+                        FileOpenFlags flags,
+                        unique_ptr<FileHandle> inner_handle_p,
+                        const mz_zip_archive_file_stat &file_stat,
+                        unique_ptr<data_t[]> data)
+      : ZipFileHandle(file_system, path, flags, std::move(inner_handle_p),
+                      file_stat),
+        data(std::move(data)) {}
+
+  void ReadInto(void *buffer, idx_t nr_bytes, idx_t location) override {
+    memcpy(buffer, data.get() + location, nr_bytes);
+  }
+
+private:
+  unique_ptr<data_t[]> data;
+};
+
+// A stored (uncompressed) member forwarding reads to the underlying handle at data_offset.
+class WindowedZipFileHandle final : public ZipFileHandle {
+public:
+  WindowedZipFileHandle(FileSystem &file_system, const string &path,
+                        FileOpenFlags flags,
+                        unique_ptr<FileHandle> inner_handle_p,
+                        const mz_zip_archive_file_stat &file_stat,
+                        idx_t data_offset)
+      : ZipFileHandle(file_system, path, flags, std::move(inner_handle_p),
+                      file_stat),
+        data_offset(data_offset) {}
+
+  void ReadInto(void *buffer, idx_t nr_bytes, idx_t location) override {
+    inner_handle->Read(buffer, nr_bytes, data_offset + location);
+  }
+
+private:
+  idx_t data_offset;
 };
 
 class ZipFileSystem final : public FileSystem {

--- a/src/zip_file_system.cpp
+++ b/src/zip_file_system.cpp
@@ -115,6 +115,33 @@ size_t FileSystemZipReadFunc(void *pOpaque, mz_uint64 file_ofs, void *pBuf,
   return UnsafeNumericCast<size_t>(handle->Read(pBuf, n));
 }
 
+// Offset of a stored member's data: read the 30-byte local header at
+// m_local_header_ofs to skip its name/extra fields (which the central directory
+// does not resolve), returning false if the header or data run past EOF.
+static bool StoredMemberDataOffset(FileHandle &inner,
+                                   const mz_zip_archive_file_stat &stat,
+                                   idx_t file_size, idx_t *out_offset) {
+  idx_t header_ofs = UnsafeNumericCast<idx_t>(stat.m_local_header_ofs);
+  if (file_size < 30 || header_ofs > file_size - 30) {
+    return false;
+  }
+  data_t lh[30];
+  inner.Read(lh, sizeof(lh), header_ofs);
+  // Local file header signature "PK\3\4".
+  if (lh[0] != 0x50 || lh[1] != 0x4b || lh[2] != 0x03 || lh[3] != 0x04) {
+    return false;
+  }
+  uint16_t name_len = UnsafeNumericCast<uint16_t>(lh[26] | (lh[27] << 8));
+  uint16_t extra_len = UnsafeNumericCast<uint16_t>(lh[28] | (lh[29] << 8));
+  idx_t data_off = header_ofs + 30 + name_len + extra_len;
+  if (data_off > file_size ||
+      UnsafeNumericCast<idx_t>(stat.m_uncomp_size) > file_size - data_off) {
+    return false;
+  }
+  *out_offset = data_off;
+  return true;
+}
+
 unique_ptr<FileHandle>
 ZipFileSystem::OpenFile(const string &path, FileOpenFlags flags,
                         optional_ptr<FileOpener> opener) {
@@ -181,11 +208,21 @@ ZipFileSystem::OpenFile(const string &path, FileOpenFlags flags,
       throw IOException("Unknown compression method");
     }
 
+    // Serve stored members through a windowed handle to keep DuckDB's ranged
+    // reads; compressed members fall through to the buffered path below.
+    idx_t data_offset;
+    if (file_stat.m_method == 0 && !file_stat.m_is_encrypted &&
+        StoredMemberDataOffset(*handle, file_stat, size, &data_offset)) {
+      mz_zip_reader_end(&zip);
+      return make_uniq<WindowedZipFileHandle>(
+          *this, path, flags, std::move(handle), file_stat, data_offset);
+    }
+
     auto read_buf = make_uniq_array2<data_t>(file_stat.m_uncomp_size);
     mz_zip_reader_extract_file_to_mem(
         &zip, file_stat.m_filename, read_buf.get(), file_stat.m_uncomp_size, 0);
 
-    auto zip_file_handle = make_uniq<ZipFileHandle>(
+    auto zip_file_handle = make_uniq<BufferedZipFileHandle>(
         *this, path, flags, std::move(handle), file_stat, std::move(read_buf));
 
     mz_zip_reader_end(&zip);
@@ -202,7 +239,7 @@ void ZipFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes,
   auto &t_handle = handle.Cast<ZipFileHandle>();
   auto remaining_bytes = t_handle.file_stat.m_uncomp_size - location;
   auto to_read = MinValue(UnsafeNumericCast<idx_t>(nr_bytes), remaining_bytes);
-  memcpy(buffer, t_handle.data.get() + location, to_read);
+  t_handle.ReadInto(buffer, to_read, location);
 }
 
 int64_t ZipFileSystem::Read(FileHandle &handle, void *buffer,
@@ -211,7 +248,7 @@ int64_t ZipFileSystem::Read(FileHandle &handle, void *buffer,
   auto position = t_handle.seek_offset;
   auto remaining_bytes = t_handle.file_stat.m_uncomp_size - position;
   auto to_read = MinValue(UnsafeNumericCast<idx_t>(nr_bytes), remaining_bytes);
-  memcpy(buffer, t_handle.data.get() + position, to_read);
+  t_handle.ReadInto(buffer, to_read, position);
   t_handle.seek_offset += to_read;
   return to_read;
 }


### PR DESCRIPTION
Maybe a simpler alternative to #73 which implements exclusively streaming to stored (uncompressed, zip -0) files in the zip:// protocol. These are contiguous byte ranges with a specific offset that can be determined from the local file signature.

This PR passes reads to an uncompressed file directly through to the inner file handle at the data offset allowing streaming and ranged reads.

The existing test coverage already exercises the new code, for example for reading `a.csv` or `nested_dir/some_file.csv` from `a.zip` (wherever the method is Stored):
```
❯ unzip -lv a.zip
Archive:  a.zip
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----
       0  Stored        0   0% 2025-03-29 08:30 00000000  nested_dir/
      26  Defl:N       20  23% 2025-03-29 08:35 1f60dd6b  nested_dir/some_file.jsonl
      12  Stored       12   0% 2025-01-18 03:45 c4c55dff  nested_dir/some_file.csv
      24  Stored       24   0% 2025-01-18 00:22 d9cb986c  a.csv
      26  Defl:N       20  23% 2025-03-29 08:35 6074e588  a.jsonl
      11  Stored       11   0% 2025-01-18 03:45 d76edb3f  b.csv
      26  Defl:N       20  23% 2025-03-29 08:35 cd52423a  b.jsonl
--------          -------  ---                            -------
     125              107  14%                            7 files
```

This is particularly worthwhile to bundle multiple parquet files into zip and then read from them efficiently.